### PR TITLE
Change Cache-Control on responses to no-store

### DIFF
--- a/api.go
+++ b/api.go
@@ -95,7 +95,7 @@ func (a apiServer) handleRead(res http.ResponseWriter, r *http.Request) {
 
 func (a apiServer) jsonResponse(res http.ResponseWriter, status int, response map[string]interface{}) {
 	res.Header().Set("Content-Type", "application/json")
-	res.Header().Set("Cache-Control", "no-cache")
+	res.Header().Set("Cache-Control", "no-store, max-age=0")
 	res.WriteHeader(status)
 
 	json.NewEncoder(res).Encode(response)


### PR DESCRIPTION
Indicate that the response may not be stored in any cache. The previous
value no-cache allows caches to store encrypted secrets but asks them to
verify on every request.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

https://github.com/Luzifer/ots/issues/36