### PR TITLE
Switch to Go 1.6 embed functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ default: generate
 generate: download_libs
 	docker run --rm -ti -v $(CURDIR):$(CURDIR) -w $(CURDIR)/src node:10-alpine \
 		sh -exc "npx npm@lts ci && npx npm@lts run build && chown -R $(shell id -u) ../frontend node_modules"
-	go generate
 
 publish:
 	curl -sSLo golang.sh https://raw.githubusercontent.com/Luzifer/github-publish/master/golang.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Luzifer/ots
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Luzifer/go_helpers/v2 v2.10.0

--- a/main.go
+++ b/main.go
@@ -1,8 +1,7 @@
 package main
 
-//go:generate go-bindata -pkg $GOPACKAGE -o assets.go -modtime 1 -md5checksum ./frontend/...
-
 import (
+	"embed"
 	"fmt"
 	"mime"
 	"net/http"
@@ -28,6 +27,9 @@ var (
 	product = "ots"
 	version = "dev"
 )
+
+//go:embed frontend/*
+var assets embed.FS
 
 func init() {
 	if err := rconfig.ParseAndValidate(&cfg); err != nil {
@@ -74,7 +76,7 @@ func assetDelivery(res http.ResponseWriter, r *http.Request) {
 	}
 
 	ext := assetName[strings.LastIndex(assetName, "."):]
-	assetData, err := Asset(path.Join("frontend", assetName))
+	assetData, err := assets.ReadFile(path.Join("frontend", assetName))
 	if err != nil {
 		http.Error(res, "404 not found", http.StatusNotFound)
 		return

--- a/tplFuncs.go
+++ b/tplFuncs.go
@@ -12,7 +12,10 @@ var tplFuncs = template.FuncMap{
 }
 
 func assetSRIHash(assetName string) string {
-	data := MustAsset(path.Join("frontend", assetName))
+	data, err := assets.ReadFile(path.Join("frontend", assetName))
+	if err != nil {
+		panic(err)
+	}
 
 	h := sha512.New384()
 	h.Write(data)


### PR DESCRIPTION
This means the go-bindata compile-time dependency is no longer needed.