### PR TITLE
Add kubernetes example

### DIFF
--- a/docs/k8s_example.yml
+++ b/docs/k8s_example.yml
@@ -1,0 +1,170 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ots
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis
+  namespace: ots
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: ots
+  labels:
+    app: redis
+    role: leader
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: leader
+        tier: backend
+    spec:
+      volumes:
+        - name: redis-storage
+          persistentVolumeClaim:
+            claimName: redis
+      containers:
+        - name: leader
+          image: "docker.io/redis:6.2.5-alpine"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: "/data"
+              name: redis-storage
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 15
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ots
+  labels:
+    app: redis
+    role: leader
+    tier: backend
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    role: leader
+    tier: backend
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ots
+  namespace: ots
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ots
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: ots
+        tier: frontend
+    spec:
+      containers:
+        - name: ots
+          image: "luzifer/ots:v0.19.0"
+          args: ["--storage-type", "redis"]
+          env:
+            - name: REDIS_URL
+              value: "tcp://redis.ots.svc.cluster.local:6379"
+            - name: REDIS_KEY
+              value: "ots"
+            - name: SECRET_EXPIRY
+              value: "172800"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ots
+  namespace: ots
+  labels:
+    app: ots
+    tier: frontend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app: ots
+    tier: frontend
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ots
+  namespace: ots
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    - host: ots.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: ots
+                port:
+                  number: 3000
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - ots.example.com
+      secretName: ingress-tls


### PR DESCRIPTION
The example yaml file, when applied, creates two OTS pods and a single Redis pod storing the secrets.

I don't know if this is something useful to have in the repository. I'm making this MR as I had to create the yaml anyway and noticed you have example shell scripts too.