### PR TITLE
Add security HTTP headers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,9 +41,7 @@
       document.addEventListener('DOMContentLoaded', () => window.refreshTheme())
 
       // Template variable from Golang process
-      {{- range $key, $value := .Vars }}
-      const {{ $key }} = "{{ $value }}"
-      {{- end }}
+      const version = "{{ .Version }}"
     </script>
   </head>
   <body>

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Xss-Protection", "1; mode=block")

--- a/main.go
+++ b/main.go
@@ -120,12 +120,10 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Security-Policy", cspHeader)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	if err = tpl.Execute(w, struct {
-		Vars map[string]string
+	if err := indexTpl.Execute(w, struct {
+		Version string
 	}{
-		Vars: map[string]string{
-			"version": version,
-		},
+		Version: version,
 	}); err != nil {
 		http.Error(w, errors.Wrap(err, "executing template").Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Sadly, the Vue web interface needs unsafe-inline for both stylesheets and scripts, making the CSP header a bit useless.

Browsers tend to implement CSP a bit different, so this should be tested in a few browsers. The code changed in this PR is currently live on https://ots.webserve.be and works in Firefox and Chrome.