### PR TITLE
[typo] comprimise -> compromise

### DIFF
--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -1,5 +1,5 @@
 {
-  "alert-secret-not-found": "This is not the secret you are looking for&hellip; - If you expected the secret to be here it might be comprimised as someone else might have opened the link already.",
+  "alert-secret-not-found": "This is not the secret you are looking for&hellip; - If you expected the secret to be here it might be compromised as someone else might have opened the link already.",
   "alert-something-went-wrong": "Something went wrong. I'm very sorry about this&hellip;",
   "btn-create-secret": "Create the secret!",
   "btn-new-secret": "New Secret",


### PR DESCRIPTION
Changes text "comprimise" to "compromise", as comprimise is a typo.