### PR TITLE
Fix: Adjust HTML page title to customized AppTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to be adjustable to your needs there are some ways to customize your OT
 appIcon: ''
 
 # Override the app-title, if unset or empty the default app-title
-# "OTS - One Time Secret" will be used
+# "OTS - One Time Secrets" will be used
 appTitle: ''
 
 # Disable display of the app-title (for example if you included the

--- a/customize.go
+++ b/customize.go
@@ -49,6 +49,12 @@ func loadCustomize(filename string) (customize, error) {
 	)
 }
 
+func (c *customize) defaults() {
+	if len(c.AppTitle) == 0 {
+		c.AppTitle = "OTS - One Time Secrets"
+	}
+}
+
 func (c customize) ToJSON() (string, error) {
 	j, err := json.Marshal(c)
 	return string(j), errors.Wrap(err, "marshalling JSON")

--- a/customize.go
+++ b/customize.go
@@ -43,19 +43,22 @@ func loadCustomize(filename string) (customize, error) {
 	}
 	defer cf.Close()
 
-	return cust, errors.Wrap(
-		yaml.NewDecoder(cf).Decode(&cust),
-		"decoding customize file",
-	)
-}
-
-func (c *customize) defaults() {
-	if len(c.AppTitle) == 0 {
-		c.AppTitle = "OTS - One Time Secrets"
+	if err = yaml.NewDecoder(cf).Decode(&cust); err != nil {
+		return cust, errors.Wrap(err, "decoding customize file")
 	}
+
+	cust.applyFixes()
+
+	return cust, nil
 }
 
 func (c customize) ToJSON() (string, error) {
 	j, err := json.Marshal(c)
 	return string(j), errors.Wrap(err, "marshalling JSON")
+}
+
+func (c *customize) applyFixes() {
+	if len(c.AppTitle) == 0 {
+		c.AppTitle = "OTS - One Time Secrets"
+	}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
       rel="stylesheet"
     >
 
-    <title>OTS - One Time Secrets</title>
+    <title>{{ .Customize.AppTitle }}</title>
 
     <script nonce="{{ .InlineContentNonce }}">
       window.getTheme = () => localStorage.getItem('set-color-scheme') || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')

--- a/main.go
+++ b/main.go
@@ -73,7 +73,6 @@ func initApp() error {
 	if cust, err = loadCustomize(cfg.Customize); err != nil {
 		return errors.Wrap(err, "loading customizations")
 	}
-	cust.defaults()
 
 	frontendFS, err := fs.Sub(embeddedAssets, "frontend")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func initApp() error {
 	if cust, err = loadCustomize(cfg.Customize); err != nil {
 		return errors.Wrap(err, "loading customizations")
 	}
+	cust.defaults()
 
 	frontendFS, err := fs.Sub(embeddedAssets, "frontend")
 	if err != nil {

--- a/src/app.vue
+++ b/src/app.vue
@@ -18,7 +18,7 @@
           class="mr-1"
           :src="customize.appIcon"
         >
-        <span v-if="!customize.disableAppTitle">{{ customize.appTitle || 'OTS - One Time Secrets' }}</span>
+        <span v-if="!customize.disableAppTitle">{{ customize.appTitle }}</span>
       </b-navbar-brand>
 
       <b-navbar-toggle target="nav-collapse" />


### PR DESCRIPTION
The existing customize feature only changed the title in the navbar.