### PR TITLE
Use OCI Label defaults on Docker images

### DIFF
--- a/.git_changerelease.yaml
+++ b/.git_changerelease.yaml
@@ -21,5 +21,8 @@ pre_commit_commands:
   - |-
     yq -iP ".services.app.build.context = \"https://github.com/Luzifer/ots.git#v${TAG_VERSION}\"" docker-compose.yml
     git add docker-compose.yml
+  - |-
+    sed -i -E "s@org.opencontainers.image.version='[^']*'@org.opencontainers.image.version='${TAG_VERSION}'@" Dockerfile Dockerfile.minimal
+    git add Dockerfile Dockerfile.minimal
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ARG BUILD_DATE
 ARG APP_VERSION
 
 LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
-    org.opencontainers.image.created=$BUILD_DATE \
     org.opencontainers.image.version=$APP_VERSION \
     org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
     org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,8 @@ RUN set -ex \
 
 FROM alpine:latest
 
-ARG BUILD_DATE
-ARG APP_VERSION
-
 LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
-    org.opencontainers.image.version=$APP_VERSION \
+    org.opencontainers.image.version='v1.11.1' \
     org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
     org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \
     org.opencontainers.image.source='https://github.com/Luzifer/ots' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,16 @@ RUN set -ex \
 
 FROM alpine:latest
 
-LABEL maintainer "Knut Ahlers <knut@ahlers.me>"
+ARG BUILD_DATE
+ARG APP_VERSION
+
+LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.version=$APP_VERSION \
+    org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
+    org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \
+    org.opencontainers.image.source='https://github.com/Luzifer/ots' \
+    org.opencontainers.image.licenses='Apache-2.0'
 
 RUN set -ex \
  && apk --no-cache add \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -29,7 +29,6 @@ ARG BUILD_DATE
 ARG APP_VERSION
 
 LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
-    org.opencontainers.image.created=$BUILD_DATE \
     org.opencontainers.image.version $APP_VERSION \
     org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
     org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -25,11 +25,8 @@ RUN set -ex \
 
 FROM scratch
 
-ARG BUILD_DATE
-ARG APP_VERSION
-
 LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
-    org.opencontainers.image.version $APP_VERSION \
+    org.opencontainers.image.version='v1.11.1' \
     org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
     org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \
     org.opencontainers.image.source='https://github.com/Luzifer/ots' \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -25,7 +25,16 @@ RUN set -ex \
 
 FROM scratch
 
-LABEL maintainer "Knut Ahlers <knut@ahlers.me>"
+ARG BUILD_DATE
+ARG APP_VERSION
+
+LABEL org.opencontainers.image.authors='Knut Ahlers <knut@ahlers.me>' \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.version $APP_VERSION \
+    org.opencontainers.image.url='https://hub.docker.com/r/luzifer/ots/' \
+    org.opencontainers.image.documentation='https://github.com/Luzifer/ots/wiki' \
+    org.opencontainers.image.source='https://github.com/Luzifer/ots' \
+    org.opencontainers.image.licenses='Apache-2.0'
 
 COPY --from=builder /go/bin/ots /usr/local/bin/ots
 


### PR DESCRIPTION
According to OCI these labels should be applied: https://github.com/opencontainers/image-spec/blob/main/annotations.md

I didn't found the docker image build, maybe you're using docker hub build. Idea would be to pass `BUILD_DATE` and `APP_VERSION` as build arguments