### PR TITLE
Add option to disallow unencrypted secrets

### DIFF
--- a/pkg/customization/customize.go
+++ b/pkg/customization/customize.go
@@ -40,6 +40,8 @@ type (
 		MetricsAllowedSubnets []string `json:"-" yaml:"metricsAllowedSubnets"`
 		OverlayFSPath         string   `json:"-" yaml:"overlayFSPath"`
 		UseFormalLanguage     bool     `json:"-" yaml:"useFormalLanguage"`
+
+		RejectUnencryptedSecrets bool `json:"-" yaml:"rejectUnencryptedSecrets"`
 	}
 )
 


### PR DESCRIPTION
> As a operator of a public instance of OTS I want to ensure I really don't get plain text secrets in my store someone could blame me to have read.

Therefore this PR introduces an option to reject plain-text secrets by checking whether there is a base64 encoded OpenSSL header in the submitted secret. The option by default is disabled in order to keep the previous behavior and can be enabled through the customizations.