### PR TITLE
Update K8s example and include customize.yaml

### DIFF
--- a/docs/k8s_example.yml
+++ b/docs/k8s_example.yml
@@ -14,27 +14,27 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: redis
+  name: ots-redis
   labels:
-    app: redis
+    app: ots-redis
     role: leader
     tier: backend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: redis
+      app: ots-redis
   template:
     metadata:
       labels:
-        app: redis
+        app: ots-redis
         role: leader
         tier: backend
     spec:
       volumes:
         - name: redis-storage
           persistentVolumeClaim:
-            claimName: redis
+            claimName: ots-redis
       containers:
         - name: leader
           image: "docker.io/redis:6.2.5-alpine"
@@ -62,9 +62,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: ots-redis
   labels:
-    app: redis
+    app: ots-redis
     role: leader
     tier: backend
 spec:
@@ -72,7 +72,7 @@ spec:
     - port: 6379
       targetPort: 6379
   selector:
-    app: redis
+    app: ots-redis
     role: leader
     tier: backend
 
@@ -115,7 +115,7 @@ spec:
           args: ["--storage-type", "redis", "--customize", "/custom/customize.yml"]
           env:
             - name: REDIS_URL
-              value: "tcp://redis.ots.svc.cluster.local:6379"
+              value: "tcp://ots-redis:6379"
             - name: REDIS_KEY
               value: "ots"
             - name: SECRET_EXPIRY
@@ -174,4 +174,4 @@ spec:
   tls:
     - hosts:
         - ots.example.com
-      secretName: ingress-tls
+      secretName: ots-ingress-tls

--- a/docs/k8s_example.yml
+++ b/docs/k8s_example.yml
@@ -89,7 +89,7 @@ spec:
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
-  name: "custom"
+  name: "ots-customize"
   namespace: "ots"
 data:
   customize.yml: |
@@ -119,7 +119,7 @@ spec:
       volumes:
         - name: custom
           configMap:
-            name: custom
+            name: ots-cutomize
       containers:
         - name: ots
           image: "luzifer/ots:v1.10.0"

--- a/docs/k8s_example.yml
+++ b/docs/k8s_example.yml
@@ -86,6 +86,19 @@ spec:
     tier: backend
 
 ---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "custom"
+  namespace: "ots"
+data:
+  customize.yml: |
+    appTitle: "My very customized OTS"
+    disableQRSupport: true
+    maxAttachmentSizeTotal: 1048576
+    maxSecretSize: 2097152
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -103,10 +116,14 @@ spec:
         app: ots
         tier: frontend
     spec:
+      volumes:
+        - name: custom
+          configMap:
+            name: custom
       containers:
         - name: ots
-          image: "luzifer/ots:v0.19.0"
-          args: ["--storage-type", "redis"]
+          image: "luzifer/ots:v1.10.0"
+          args: ["--storage-type", "redis", "--customize", "/custom/customize.yml"]
           env:
             - name: REDIS_URL
               value: "tcp://redis.ots.svc.cluster.local:6379"
@@ -114,6 +131,9 @@ spec:
               value: "ots"
             - name: SECRET_EXPIRY
               value: "172800"
+          volumeMounts:
+            - mountPath: "/custom"
+              name: custom
           resources:
             requests:
               cpu: 100m

--- a/docs/k8s_example.yml
+++ b/docs/k8s_example.yml
@@ -1,15 +1,8 @@
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: ots
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: redis
-  namespace: ots
+  name: ots-redis
 spec:
   accessModes:
     - ReadWriteOnce
@@ -22,7 +15,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  namespace: ots
   labels:
     app: redis
     role: leader
@@ -71,7 +63,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: ots
   labels:
     app: redis
     role: leader
@@ -90,7 +81,6 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "ots-customize"
-  namespace: "ots"
 data:
   customize.yml: |
     appTitle: "My very customized OTS"
@@ -103,7 +93,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ots
-  namespace: ots
 spec:
   replicas: 2
   selector:
@@ -151,7 +140,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ots
-  namespace: ots
   labels:
     app: ots
     tier: frontend
@@ -168,7 +156,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ots
-  namespace: ots
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Updates the example to a recent OTS version that supports customization and shows how to inject the customize.yml file.

I'm not sure whether you want to keep the k8s yaml example in the repo, as you seem to be steering towards helm. For very simple deployments like these, I don't use helm myself. It just adds another useless layer of yaml files, in my opinion. Let me know if you would like me to remove the example instead. :smile: