### PR TITLE
refactor: modified build container to use golang:1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM luzifer/archlinux as builder
+FROM golang:1-alpine AS builder
 
 ENV CGO_ENABLED=0 \
     GOPATH=/go \
@@ -8,12 +8,11 @@ COPY . /go/src/github.com/Luzifer/ots
 WORKDIR /go/src/github.com/Luzifer/ots
 
 RUN set -ex \
- && pacman --noconfirm -Syy \
+ && apk update && apk add \
       curl \
       git \
-      go \
       make \
-      nodejs-lts-hydrogen \
+      nodejs-lts \
       npm \
       tar \
       unzip \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,4 +1,4 @@
-FROM luzifer/archlinux as builder
+FROM golang:1-alpine AS builder
 
 ENV CGO_ENABLED=0 \
     GOPATH=/go \
@@ -8,12 +8,11 @@ COPY . /go/src/github.com/Luzifer/ots
 WORKDIR /go/src/github.com/Luzifer/ots
 
 RUN set -ex \
- && pacman --noconfirm -Syy \
+ && apk update && apk add \
       curl \
       git \
-      go \
       make \
-      nodejs-lts-hydrogen \
+      nodejs-lts \
       npm \
       tar \
       unzip \


### PR DESCRIPTION
This change enables the container to be built for arm64 (and possibly other) architecture.

The vanilla alpine image was not used because it does not provide the version of golang required by the go.mod file.