### PR TITLE
Add periodic in-memory store pruner

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -102,8 +102,5 @@ func (s *storageMem) ReadAndDestroy(id string) (string, error) {
 }
 
 func (m *memStorageSecret) hasExpired() bool {
-	if !m.Expiry.IsZero() && m.Expiry.Before(time.Now()) {
-		return true
-	}
-	return false
+	return !m.Expiry.IsZero() && m.Expiry.Before(time.Now())
 }

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -19,14 +19,14 @@ type (
 	storageMem struct {
 		sync.RWMutex
 		store           map[string]memStorageSecret
-		storePruneTimer time.Ticker
+		storePruneTimer *time.Ticker
 	}
 )
 
 // New creates a new In-Mem storage
 func New() storage.Storage {
 	store := &storageMem{
-		storePruneTimer: *time.NewTicker(time.Minute),
+		storePruneTimer: time.NewTicker(time.Minute),
 		store:           make(map[string]memStorageSecret),
 	}
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -26,8 +26,8 @@ type (
 // New creates a new In-Mem storage
 func New() storage.Storage {
 	store := &storageMem{
-		storePruneTimer: time.NewTicker(time.Minute),
 		store:           make(map[string]memStorageSecret),
+		storePruneTimer: time.NewTicker(time.Minute),
 	}
 
 	go store.storePruner()

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -18,8 +18,8 @@ type (
 
 	storageMem struct {
 		sync.RWMutex
-		storePruneTimer time.Ticker
 		store           map[string]memStorageSecret
+		storePruneTimer time.Ticker
 	}
 )
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -18,14 +18,37 @@ type (
 
 	storageMem struct {
 		sync.RWMutex
-		store map[string]memStorageSecret
+		storePruneTimer time.Ticker
+		store           map[string]memStorageSecret
 	}
 )
 
 // New creates a new In-Mem storage
 func New() storage.Storage {
-	return &storageMem{
-		store: make(map[string]memStorageSecret),
+	store := &storageMem{
+		storePruneTimer: *time.NewTicker(time.Minute),
+		store:           make(map[string]memStorageSecret),
+	}
+
+	go store.storePruner()
+
+	return store
+}
+
+func (s *storageMem) storePruner() {
+	for range s.storePruneTimer.C {
+		s.pruneStore()
+	}
+}
+
+func (s *storageMem) pruneStore() {
+	s.Lock()
+	defer s.Unlock()
+
+	for k, v := range s.store {
+		if v.hasExpired() {
+			delete(s.store, k)
+		}
 	}
 }
 
@@ -68,9 +91,19 @@ func (s *storageMem) ReadAndDestroy(id string) (string, error) {
 
 	defer delete(s.store, id)
 
-	if !secret.Expiry.IsZero() && secret.Expiry.Before(time.Now()) {
+	// Still check to see if the secret has expired in order to prevent a
+	// race condition where a secret has expired but the the store pruner has
+	// not yet been invoked.
+	if secret.hasExpired() {
 		return "", storage.ErrSecretNotFound
 	}
 
 	return secret.Secret, nil
+}
+
+func (m *memStorageSecret) hasExpired() bool {
+	if !m.Expiry.IsZero() && m.Expiry.Before(time.Now()) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Implement better memory management for the in memory store.

Currently secrets only get deleted once they are read while still valid or attempted to be read once expired. This change implements a go routine that periodically iterates over secrets held in memory and if the secret is expired, deletes it. This will lead to better memory efficiency as expired secrets without any desire to be read won't linger in memory indefinitely. 