### PR TITLE
Add alternative `appIcon` for dark-mode

### DIFF
--- a/pkg/customization/customize.go
+++ b/pkg/customization/customize.go
@@ -23,6 +23,7 @@ type (
 	// Customize holds the structure of the customization file
 	Customize struct {
 		AppIcon              string `json:"appIcon,omitempty" yaml:"appIcon"`
+		AppIconDark          string `json:"appIconDark,omitempty" yaml:"appIconDark"`
 		AppTitle             string `json:"appTitle,omitempty" yaml:"appTitle"`
 		DisableAppTitle      bool   `json:"disableAppTitle,omitempty" yaml:"disableAppTitle"`
 		DisablePoweredBy     bool   `json:"disablePoweredBy,omitempty" yaml:"disablePoweredBy"`

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -7,13 +7,13 @@
         @click.prevent="$root.navigate('/')"
       >
         <i
-          v-if="!$root.customize.appIcon"
+          v-if="!appIcon"
           class="fas fa-user-secret mr-1"
         />
         <img
           v-else
           class="mr-1"
-          :src="$root.customize.appIcon"
+          :src="appIcon"
         >
         <span v-if="!$root.customize.disableAppTitle">{{ $root.customize.appTitle }}</span>
       </a>
@@ -77,6 +77,17 @@
 
 <script>
 export default {
+  computed: {
+    appIcon() {
+      // Use specified icon or fall back to null
+      const appIcon = this.$root.customize.appIcon || null
+      // Use specified icon or fall back to light-mode appIcon (which might be null)
+      const darkIcon = this.$root.customize.appIconDark || appIcon
+
+      return this.$root.darkTheme ? darkIcon : appIcon
+    },
+  },
+
   name: 'AppNavbar',
 }
 </script>


### PR DESCRIPTION
Customization:

```yaml
appIcon: 'appIconL.png'
appIconDark: 'appIconD.png'
overlayFSPath: '/tmp/overlay'
```

Assets used:
| Filename | Icon |
| --- | :---: |
| `appIconD.png` | ![appIconD](https://github.com/user-attachments/assets/8b2020a8-273c-44a6-af66-48e3db9e3a87) |
| `appIconL.png` | ![appIconL](https://github.com/user-attachments/assets/68bd6cce-f65a-4c50-97b9-14168f1d0aee) |

Result:
![image](https://github.com/user-attachments/assets/60d53edc-5e5c-4460-aa26-a1cce3b11197)
![image](https://github.com/user-attachments/assets/d9bd31b1-bf57-448e-bbfd-b13530ac3c5e)