### PR TITLE
Add CORS handling for /api/create endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -56,6 +56,13 @@ func (a apiServer) Register(r *mux.Router) {
 }
 
 func (a apiServer) handleCreate(res http.ResponseWriter, r *http.Request) {
+	res.Header().Set("Access-Control-Allow-Origin", "*")
+	res.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	if r.Method == http.MethodOptions {
+		res.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	if cust.MaxSecretSize > 0 {
 		// As a safeguard against HUGE payloads behind a misconfigured
 		// proxy we take double the maximum secret size after which we

--- a/api.go
+++ b/api.go
@@ -56,11 +56,14 @@ func (a apiServer) Register(r *mux.Router) {
 }
 
 func (a apiServer) handleCreate(res http.ResponseWriter, r *http.Request) {
-	res.Header().Set("Access-Control-Allow-Origin", "*")
-	res.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	if r.Method == http.MethodOptions {
-		res.WriteHeader(http.StatusNoContent)
-		return
+	if cust.AddCORSHeaders {
+		res.Header().Set("Access-Control-Allow-Origin", "*")
+		res.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		if r.Method == http.MethodOptions {
+			res.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 	}
 
 	if cust.MaxSecretSize > 0 {

--- a/pkg/customization/customize.go
+++ b/pkg/customization/customize.go
@@ -41,6 +41,7 @@ type (
 		MetricsAllowedSubnets []string `json:"-" yaml:"metricsAllowedSubnets"`
 		OverlayFSPath         string   `json:"-" yaml:"overlayFSPath"`
 		UseFormalLanguage     bool     `json:"-" yaml:"useFormalLanguage"`
+		AddCORSHeaders        bool     `json:"-" yaml:"addCORSHeaders"`
 
 		FooterLinks []FooterLink `json:"footerLinks,omitempty" yaml:"footerLinks"`
 	}


### PR DESCRIPTION
Sets Access-Control-Allow-* headers on requests to the /api/create endpoint.
This allows the JSON API to be used for secret creation from a web app hosted at a different domain.