### PR TITLE
feat: human readable options, and a sane default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Requirements:
 - Node v22+
 - Tilt v0.33+
 
-Run `tilt up`, and see `http://localhost:10350/` for the Tilt dashboard.
+Run `tilt up`, and see http://localhost:10350/ for the Tilt dashboard.
 
-Front-end application is available at `http://localhost:15641/`.
+Front-end application is available at http://localhost:15641/.
 
 ## Localize to your own language
 

--- a/pkg/customization/customize.go
+++ b/pkg/customization/customize.go
@@ -30,8 +30,10 @@ type (
 		DisableQRSupport     bool   `json:"disableQRSupport,omitempty" yaml:"disableQRSupport"`
 		DisableThemeSwitcher bool   `json:"disableThemeSwitcher,omitempty" yaml:"disableThemeSwitcher"`
 
-		DisableExpiryOverride bool    `json:"disableExpiryOverride,omitempty" yaml:"disableExpiryOverride"`
-		ExpiryChoices         []int64 `json:"expiryChoices,omitempty" yaml:"expiryChoices"`
+		DisableExpiryOverride bool     `json:"disableExpiryOverride,omitempty" yaml:"disableExpiryOverride"`
+		ExpiryChoices         []int64  `json:"expiryChoices,omitempty" yaml:"expiryChoices"`
+		ExpiryChoicesHuman    []string `json:"expiryChoicesHuman,omitempty" yaml:"expiryChoicesHuman"`
+		DefaultExpiryHuman    string   `json:"defaultExpiryHuman,omitempty" yaml:"defaultExpiryHuman"`
 
 		AcceptedFileTypes      string `json:"acceptedFileTypes" yaml:"acceptedFileTypes"`
 		DisableFileAttachment  bool   `json:"disableFileAttachment" yaml:"disableFileAttachment"`

--- a/src/components/create.vue
+++ b/src/components/create.vue
@@ -185,7 +185,7 @@ export default defineComponent({
     },
 
     expiryChoices(): Record<string, string | null>[] {
-      if (this.$root.customize.expiryChoicesHuman) {
+      if (this.customize.expiryChoicesHuman) {
         return this.expiryChoicesHuman
       }
 
@@ -219,7 +219,7 @@ export default defineComponent({
         choices.push({ text: this.$t('expire-default'), value: null })
       }
 
-      for (const choice of this.$root.customize.expiryChoicesHuman || defaultExpiryChoicesHuman) {
+      for (const choice of this.customize.expiryChoicesHuman || defaultExpiryChoicesHuman) {
         const option = { value: choice }
 
         const unit = choice.slice(-1)
@@ -277,15 +277,7 @@ export default defineComponent({
   created(): void {
     this.checkWriteAccess()
 
-    this.$root.$watch(
-      'customize',
-      newVal => {
-        if (newVal) {
-          this.initExpiry()
-        }
-      },
-      { immediate: true },
-    )
+    this.initExpiry()
   },
 
   data() {
@@ -308,13 +300,13 @@ export default defineComponent({
     _getTextForAmount(unit, amount) {
       switch (unit) {
       case 'd':
-        return this.$tc('expire-n-days', amount)
+        return this.$t('expire-n-days', amount)
       case 'h':
-        return this.$tc('expire-n-hours', amount)
+        return this.$t('expire-n-hours', amount)
       case 'm':
-        return this.$tc('expire-n-minutes', amount)
+        return this.$t('expire-n-minutes', amount)
       case 's':
-        return this.$tc('expire-n-seconds', amount)
+        return this.$t('expire-n-seconds', amount)
       }
 
       return amount
@@ -434,28 +426,29 @@ export default defineComponent({
     },
 
     hasValidDefaultExpiryHuman() {
-      const defaultExpiry = this.$root.customize.defaultExpiryHuman || false
+      const defaultExpiry = this.customize.defaultExpiryHuman || false
       if (defaultExpiry === false) {
         return false
       }
 
-      if (!this.$root.customize.expiryChoicesHuman) {
+      if (!this.customize.expiryChoicesHuman) {
         return false
       }
 
-      return this.$root.customize.expiryChoicesHuman.includes(defaultExpiry)
+      return this.customize.expiryChoicesHuman.includes(defaultExpiry)
     },
 
     initExpiry() {
       const match = document.cookie.match(/(?:^|;\s*)selectedExpiry=([^;]*)/)
       this.selectedExpiry = match
         ? decodeURIComponent(match[1])
-        : this.$root.customize?.defaultExpiryHuman || null
+        : this.customize?.defaultExpiryHuman || null
 
-      if (!this.$root.customize?.expiryChoicesHuman) {
+      if (!this.customize?.expiryChoicesHuman) {
         return
       }
-      if (!this.$root.customize?.expiryChoicesHuman.includes(this.selectedExpiry)) {
+
+      if (!this.customize?.expiryChoicesHuman.includes(this.selectedExpiry)) {
         this.selectedExpiry = null
       }
     },

--- a/src/components/create.vue
+++ b/src/components/create.vue
@@ -122,8 +122,11 @@
 </template>
 
 <script lang="ts">
+import {
+  bytesToHuman,
+  durationToSeconds,
+} from '../helpers'
 import appCrypto from '../crypto.ts'
-import { bytesToHuman } from '../helpers'
 import { defineComponent } from 'vue'
 import FilesDisplay from './fileDisplay.vue'
 import GrowArea from './growarea.vue'
@@ -140,6 +143,19 @@ const defaultExpiryChoices = [
   60 * 60, // 1 hour
   30 * 60, // 30 minutes
   5 * 60, // 5 minutes
+]
+
+const defaultExpiryChoicesHuman = [
+  '90d',
+  '30d',
+  '7d',
+  '3d',
+  '24h', // or 1d, equivalent
+  '12h',
+  '4h',
+  '1h',
+  '30m',
+  '5m',
 ]
 
 /*
@@ -169,6 +185,10 @@ export default defineComponent({
     },
 
     expiryChoices(): Record<string, string | null>[] {
+      if (this.$root.customize.expiryChoicesHuman) {
+        return this.expiryChoicesHuman
+      }
+
       const choices = [{ text: this.$t('expire-default'), value: null as string | null }]
 
       for (const choice of this.customize.expiryChoices || defaultExpiryChoices) {
@@ -186,6 +206,26 @@ export default defineComponent({
         } else {
           option.text = this.$t('expire-n-seconds', choice)
         }
+
+        choices.push(option)
+      }
+
+      return choices
+    },
+
+    expiryChoicesHuman() {
+      const choices = []
+      if (!this.hasValidDefaultExpiryHuman()) {
+        choices.push({ text: this.$t('expire-default'), value: null })
+      }
+
+      for (const choice of this.$root.customize.expiryChoicesHuman || defaultExpiryChoicesHuman) {
+        const option = { value: choice }
+
+        const unit = choice.slice(-1)
+        const amount = parseInt(choice.slice(0, -1), 10)
+
+        option.text = this._getTextForAmount(unit, amount)
 
         choices.push(option)
       }
@@ -236,6 +276,16 @@ export default defineComponent({
 
   created(): void {
     this.checkWriteAccess()
+
+    this.$root.$watch(
+      'customize',
+      newVal => {
+        if (newVal) {
+          this.initExpiry()
+        }
+      },
+      { immediate: true },
+    )
   },
 
   data() {
@@ -243,6 +293,7 @@ export default defineComponent({
       attachedFiles: [],
       canWrite: null,
       createRunning: false,
+      expiryInitialized: false,
       fileSize: 0,
       secret: '',
       securePassword: null,
@@ -254,6 +305,21 @@ export default defineComponent({
   emits: ['error', 'navigate'],
 
   methods: {
+    _getTextForAmount(unit, amount) {
+      switch (unit) {
+      case 'd':
+        return this.$tc('expire-n-days', amount)
+      case 'h':
+        return this.$tc('expire-n-hours', amount)
+      case 'm':
+        return this.$tc('expire-n-minutes', amount)
+      case 's':
+        return this.$tc('expire-n-seconds', amount)
+      }
+
+      return amount
+    },
+
     bytesToHuman,
 
     checkWriteAccess(): Promise<void> {
@@ -300,7 +366,7 @@ export default defineComponent({
         .then(secret => {
           let reqURL = 'api/create'
           if (this.selectedExpiry !== null) {
-            reqURL = `api/create?expire=${this.selectedExpiry}`
+            reqURL = `api/create?expire=${durationToSeconds(this.selectedExpiry)}`
           }
 
           return fetch(reqURL, {
@@ -367,6 +433,33 @@ export default defineComponent({
       this.$refs.createSecretFiles.value = ''
     },
 
+    hasValidDefaultExpiryHuman() {
+      const defaultExpiry = this.$root.customize.defaultExpiryHuman || false
+      if (defaultExpiry === false) {
+        return false
+      }
+
+      if (!this.$root.customize.expiryChoicesHuman) {
+        return false
+      }
+
+      return this.$root.customize.expiryChoicesHuman.includes(defaultExpiry)
+    },
+
+    initExpiry() {
+      const match = document.cookie.match(/(?:^|;\s*)selectedExpiry=([^;]*)/)
+      this.selectedExpiry = match
+        ? decodeURIComponent(match[1])
+        : this.$root.customize?.defaultExpiryHuman || null
+
+      if (!this.$root.customize?.expiryChoicesHuman) {
+        return
+      }
+      if (!this.$root.customize?.expiryChoicesHuman.includes(this.selectedExpiry)) {
+        this.selectedExpiry = null
+      }
+    },
+
     isAcceptedBy(fileMeta: any, accept: string): boolean {
       if (/^(?:[a-z]+|\*)\/(?:[a-zA-Z0-9.+_-]+|\*)$/.test(accept)) {
         // That's likely supposed to be a mime-type
@@ -395,5 +488,17 @@ export default defineComponent({
   },
 
   name: 'AppCreate',
+
+  watch: {
+    selectedExpiry(newVal) {
+      if (!this.expiryInitialized) {
+        this.expiryInitialized = true
+
+        return
+      }
+
+      document.cookie = `selectedExpiry=${newVal || ''}; path=/; max-age=${60 * 60 * 24 * 365}`
+    },
+  },
 })
 </script>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,6 +16,31 @@ function bytesToHuman(bytes: number): string {
   return `${bytes} B`
 }
 
+function durationToSeconds(duration) {
+  const regex = /^(\d+)([smhd])$/
+  const match = typeof duration === 'string' && duration.match(regex)
+  if (!match) {
+    return duration
+  }
+
+  const value = parseInt(match[1], 10)
+  const unit = match[2]
+
+  switch (unit) {
+  case 's':
+    return value
+  case 'm':
+    return value * 60
+  case 'h':
+    return value * 3600
+  case 'd':
+    return value * 86400
+  }
+
+  return duration // Fallback: return as-is
+}
+
 export {
   bytesToHuman,
+  durationToSeconds,
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,7 +9,7 @@ function bytesToHuman(bytes: number): string {
     { thresh: 1024, unit: 'KiB' },
   ]) {
     if (bytes > t.thresh) {
-      return `${(bytes / t.thresh).toFixed(1)} ${t.unit}`
+      return `${parseFloat((bytes / t.thresh).toFixed(1))} ${t.unit}`
     }
   }
 


### PR DESCRIPTION
add expiryChoicesHuman, remove 'default expiry' from dropdown

Focussing on front-end UI, 'default expiry' means nothing. Rather than relying on non-human readable, unix timestamps, introducing human readable options: (s)econds, (m)inutes, (h)ours, (d)ays. The defaultExpiryHuman should be any of the options for expiryChoicesHuman. If it's not, it'll fallback to `null`, which will fallback to the `defaultExpiry` behaviour as it is now

Save the selected option as a cookie, only after initially loaded. Load from cookie on page load. API is not changed, still accepts seconds

---

I've seen a (few?) discussions on the default expiry being confusing, and I concur. This is my attempt to deal with that. I can't oversee the changes required for cli tool. I also am very aware that this change is backwards compatible, but picking this over the other introduces a breaking change.

I've chaos-monkey tested this a lot: I've not been able to break this, by removing the cookie, setting an illegal value, etc.

Let me know what you think!