### PR TITLE
feat: disable search engine indexing via configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,8 @@ func main() {
 
 	r.HandleFunc("/", handleIndex).
 		Methods(http.MethodGet)
+	r.HandleFunc("/robots.txt", handleRobotsTXT).
+		Methods(http.MethodGet)
 	r.PathPrefix("/").HandlerFunc(assetDelivery).
 		Methods(http.MethodGet)
 
@@ -239,6 +241,18 @@ func handleIndex(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, errors.Wrap(err, "executing template").Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+func handleRobotsTXT(w http.ResponseWriter, _ *http.Request) {
+	// If explicitly set to false, do not create robots.txt.
+	if cust.DisableSearchIndex != nil && !*cust.DisableSearchIndex {
+		http.NotFound(w, nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write([]byte("User-agent: *\nDisallow: /\n"))
 }
 
 func handleRemoveAcceptEncoding(next http.Handler) http.Handler {

--- a/pkg/customization/customize.go
+++ b/pkg/customization/customize.go
@@ -28,6 +28,7 @@ type (
 		DisableAppTitle      bool   `json:"disableAppTitle,omitempty" yaml:"disableAppTitle"`
 		DisablePoweredBy     bool   `json:"disablePoweredBy,omitempty" yaml:"disablePoweredBy"`
 		DisableQRSupport     bool   `json:"disableQRSupport,omitempty" yaml:"disableQRSupport"`
+		DisableSearchIndex  *bool   `json:"disable-search-index" yaml:"disableSearchIndex" default:"true"`
 		DisableThemeSwitcher bool   `json:"disableThemeSwitcher,omitempty" yaml:"disableThemeSwitcher"`
 
 		DisableExpiryOverride bool    `json:"disableExpiryOverride,omitempty" yaml:"disableExpiryOverride"`


### PR DESCRIPTION
# Developer Certificate of Origin
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

# PR

Resolves #221 

This PR allows users to allow/deny their OTS instance from being indexed by search engines (that abide by robots.txt). Default behavior is to deny indexing for all user agents on all paths. Unless explicitly set (```disableSearchIndex: false```), a robots.txt file with the below contents will be served on /robots.txt
```
User-agent: *
Disallow: /
```

I git pulled my repo and ran with no issues. Everything compiled with no errors and I was able to ```go run . --config config-file.yaml``` with ```disableSearchIndex : false``` to change /robots.txt back to a 404 error.

Wiki must be updated with the new configuration option if this PR is merged.