### PR TITLE
Added support for listening to a unix socket file

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"embed"
 	"encoding/base64"
@@ -25,7 +26,10 @@ import (
 	"github.com/Luzifer/rconfig/v2"
 )
 
-const scriptNonceSize = 32
+const (
+	scriptNonceSize     = 32
+	socketDirPermission = 0o750
+)
 
 var (
 	cfg struct {
@@ -256,6 +260,9 @@ func handleRemoveAcceptEncoding(next http.Handler) http.Handler {
 }
 
 func getListener(addr string) (net.Listener, error) {
+	lc := net.ListenConfig{}
+	ctx := context.Background()
+
 	if strings.HasPrefix(addr, "unix:") {
 		path := strings.TrimPrefix(addr, "unix:")
 		if info, err := os.Stat(path); err == nil {
@@ -266,12 +273,14 @@ func getListener(addr string) (net.Listener, error) {
 			}
 		}
 
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), socketDirPermission); err != nil {
 			return nil, errors.Wrap(err, "creating socket directory")
 		}
 
-		return net.Listen("unix", path)
+		l, err := lc.Listen(ctx, "unix", path)
+		return l, errors.Wrap(err, "creating unix listener")
 	}
 
-	return net.Listen("tcp", addr)
+	l, err := lc.Listen(ctx, "tcp", addr)
+	return l, errors.Wrap(err, "creating tcp listener")
 }

--- a/main.go
+++ b/main.go
@@ -6,8 +6,10 @@ import (
 	"encoding/base64"
 	"io/fs"
 	"mime"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
@@ -164,17 +166,22 @@ func main() {
 		"version":       version,
 	}).Info("ots started")
 
+	l, err := getListener(cfg.Listen)
+	if err != nil {
+		logrus.WithError(err).Fatal("creating listener")
+	}
+
 	if cfg.EnableTLS {
 		if cfg.CertFile == "" || cfg.KeyFile == "" {
 			logrus.Fatal("TLS is enabled but cert-file or key-file is not provided")
 		}
 		logrus.Infof("Starting HTTPS server on %s", cfg.Listen)
-		if err := server.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile); err != nil {
+		if err := server.ServeTLS(l, cfg.CertFile, cfg.KeyFile); err != nil {
 			logrus.WithError(err).Fatal("HTTPS server quit unexpectedly")
 		}
 	} else {
 		logrus.Infof("Starting HTTP server on %s", cfg.Listen)
-		if err := server.ListenAndServe(); err != nil {
+		if err := server.Serve(l); err != nil {
 			logrus.WithError(err).Fatal("HTTP server quit unexpectedly")
 		}
 	}
@@ -246,4 +253,25 @@ func handleRemoveAcceptEncoding(next http.Handler) http.Handler {
 		r.Header.Del("Accept-Encoding")
 		next.ServeHTTP(w, r)
 	})
+}
+
+func getListener(addr string) (net.Listener, error) {
+	if strings.HasPrefix(addr, "unix:") {
+		path := strings.TrimPrefix(addr, "unix:")
+		if info, err := os.Stat(path); err == nil {
+			if info.Mode()&os.ModeSocket != 0 {
+				if err := os.Remove(path); err != nil {
+					return nil, errors.Wrap(err, "removing existing socket")
+				}
+			}
+		}
+
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, errors.Wrap(err, "creating socket directory")
+		}
+
+		return net.Listen("unix", path)
+	}
+
+	return net.Listen("tcp", addr)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetListener(t *testing.T) {
+	// Test TCP listener
+	l, err := getListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create TCP listener: %v", err)
+	}
+	if l.Addr().Network() != "tcp" {
+		t.Errorf("expected tcp network, got %s", l.Addr().Network())
+	}
+	l.Close()
+
+	// Test Unix listener
+	tmpDir, err := os.MkdirTemp("", "ots-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	sockPath := filepath.Join(tmpDir, "test.sock")
+	addr := "unix:" + sockPath
+
+	l, err = getListener(addr)
+	if err != nil {
+		t.Fatalf("failed to create unix listener: %v", err)
+	}
+	if l.Addr().Network() != "unix" {
+		t.Errorf("expected unix network, got %s", l.Addr().Network())
+	}
+	if l.Addr().String() != sockPath {
+		t.Errorf("expected socket path %s, got %s", sockPath, l.Addr().String())
+	}
+	l.Close()
+
+	// Test existing socket deletion
+	l, err = net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to create manual unix listener: %v", err)
+	}
+	l.Close()
+
+	l, err = getListener(addr)
+	if err != nil {
+		t.Fatalf("failed to create unix listener with existing socket: %v", err)
+	}
+	l.Close()
+
+	// Test nested directory creation
+	nestedSockPath := filepath.Join(tmpDir, "nested/dir/test.sock")
+	addr = "unix:" + nestedSockPath
+	l, err = getListener(addr)
+	if err != nil {
+		t.Fatalf("failed to create unix listener in nested dir: %v", err)
+	}
+	l.Close()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,64 +1,86 @@
 package main
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestGetListener(t *testing.T) {
-	// Test TCP listener
-	l, err := getListener("127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to create TCP listener: %v", err)
-	}
-	if l.Addr().Network() != "tcp" {
-		t.Errorf("expected tcp network, got %s", l.Addr().Network())
-	}
-	l.Close()
+func mustCloseListener(t *testing.T, l net.Listener, msg string) {
+	t.Helper()
 
-	// Test Unix listener
+	if err := l.Close(); err != nil {
+		t.Fatalf("%s: %v", msg, err)
+	}
+}
+
+func TestGetListener(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "ots-test-*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
 
-	sockPath := filepath.Join(tmpDir, "test.sock")
-	addr := "unix:" + sockPath
+	t.Run("tcp listener", func(t *testing.T) {
+		l, err := getListener("127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to create TCP listener: %v", err)
+		}
+		if l.Addr().Network() != "tcp" {
+			t.Errorf("expected tcp network, got %s", l.Addr().Network())
+		}
+		mustCloseListener(t, l, "failed to close TCP listener")
+	})
 
-	l, err = getListener(addr)
-	if err != nil {
-		t.Fatalf("failed to create unix listener: %v", err)
-	}
-	if l.Addr().Network() != "unix" {
-		t.Errorf("expected unix network, got %s", l.Addr().Network())
-	}
-	if l.Addr().String() != sockPath {
-		t.Errorf("expected socket path %s, got %s", sockPath, l.Addr().String())
-	}
-	l.Close()
+	t.Run("unix listener", func(t *testing.T) {
+		sockPath := filepath.Join(tmpDir, "test.sock")
+		addr := "unix:" + sockPath
 
-	// Test existing socket deletion
-	l, err = net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatalf("failed to create manual unix listener: %v", err)
-	}
-	l.Close()
+		l, err := getListener(addr)
+		if err != nil {
+			t.Fatalf("failed to create unix listener: %v", err)
+		}
+		if l.Addr().Network() != "unix" {
+			t.Errorf("expected unix network, got %s", l.Addr().Network())
+		}
+		if l.Addr().String() != sockPath {
+			t.Errorf("expected socket path %s, got %s", sockPath, l.Addr().String())
+		}
+		mustCloseListener(t, l, "failed to close unix listener")
+	})
 
-	l, err = getListener(addr)
-	if err != nil {
-		t.Fatalf("failed to create unix listener with existing socket: %v", err)
-	}
-	l.Close()
+	t.Run("existing socket deletion", func(t *testing.T) {
+		sockPath := filepath.Join(tmpDir, "test.sock")
+		addr := "unix:" + sockPath
 
-	// Test nested directory creation
-	nestedSockPath := filepath.Join(tmpDir, "nested/dir/test.sock")
-	addr = "unix:" + nestedSockPath
-	l, err = getListener(addr)
-	if err != nil {
-		t.Fatalf("failed to create unix listener in nested dir: %v", err)
-	}
-	l.Close()
+		lc := net.ListenConfig{}
+		l, err := lc.Listen(context.Background(), "unix", sockPath)
+		if err != nil {
+			t.Fatalf("failed to create manual unix listener: %v", err)
+		}
+		mustCloseListener(t, l, "failed to close manual unix listener")
+
+		l, err = getListener(addr)
+		if err != nil {
+			t.Fatalf("failed to create unix listener with existing socket: %v", err)
+		}
+		mustCloseListener(t, l, "failed to close unix listener with existing socket")
+	})
+
+	t.Run("nested directory creation", func(t *testing.T) {
+		nestedSockPath := filepath.Join(tmpDir, "nested/dir/test.sock")
+		addr := "unix:" + nestedSockPath
+
+		l, err := getListener(addr)
+		if err != nil {
+			t.Fatalf("failed to create unix listener in nested dir: %v", err)
+		}
+		mustCloseListener(t, l, "failed to close nested unix listener")
+	})
 }


### PR DESCRIPTION
I have added support for unix:/tmp/http.sock to listen on a socket file, when running behind a reverse proxy (eg caddy/nginx) without exposing the service on a local tcp port.