### PR TITLE
chore: specify full container image paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM docker.io/library/golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 COPY --from=ghcr.io/luzifer-docker/pnpm:v11.5.2@sha256:46d369a8379ee3cd52fca61147e5be818073896c25127407df2b2aca1ec10a9f . /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - 3000:3000
   valkey:
-    image: valkey/valkey:9.1.0-alpine
+    image: docker.io/library/valkey/valkey:9.1.0-alpine
     restart: always
     volumes:
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - 3000:3000
   valkey:
-    image: docker.io/library/valkey/valkey:9.1.0-alpine
+    image: docker.io/valkey/valkey:9.1.0-alpine
     restart: always
     volumes:
       - ./data:/data


### PR DESCRIPTION
Specify image registry URLs to stay compatible with the tools other than Docker.